### PR TITLE
allow mounting bootable USB sticks/drives

### DIFF
--- a/dsbmd.c
+++ b/dsbmd.c
@@ -2513,8 +2513,8 @@ add_device(const char *devname)
 			return (add_mtp_device(devname));
 		else if (dev.st->type == ST_PTP)
 			return (add_ptp_device(devname));
-		else if (is_parted(devname) && !match_part_dev(devname, 0)) {
-			/* Only add slices of partitioned disks. */
+		else if (!is_mountable(devname)) {
+
 			return (NULL);
 		}
 	} else if (dev.iface->type != IF_TYPE_CD)

--- a/dsbmd.c
+++ b/dsbmd.c
@@ -2514,8 +2514,10 @@ add_device(const char *devname)
 		else if (dev.st->type == ST_PTP)
 			return (add_ptp_device(devname));
 		else if (is_parted(devname) && !match_part_dev(devname, 0)) {
-			/* Only add slices of partitioned disks. */
-			return (NULL);
+		 /* In most cases, we only want to add slices of partitioned disks.
+		 * But there is a special case: ISO-FS. It is mountable by itself. */
+			fs_t *fs = getfs(devpath(devname));
+			if ((fs == NULL) || (fs->id != CD9660)) return (NULL); 
 		}
 	} else if (dev.iface->type != IF_TYPE_CD)
 		return (NULL);

--- a/dsbmd.c
+++ b/dsbmd.c
@@ -2513,8 +2513,8 @@ add_device(const char *devname)
 			return (add_mtp_device(devname));
 		else if (dev.st->type == ST_PTP)
 			return (add_ptp_device(devname));
-		else if (!is_mountable(devname)) {
-
+		else if (is_parted(devname) && !match_part_dev(devname, 0)) {
+			/* Only add slices of partitioned disks. */
 			return (NULL);
 		}
 	} else if (dev.iface->type != IF_TYPE_CD)


### PR DESCRIPTION
This is a regular, bootable (X)Ubuntu USB stick:
```
% gpart show -p /dev/da0
=>      63  61056001    da0  MBR  (29G)
        63   2563197         - free -  (1.2G)
   2563260      4736  da0s2  !239  (2.3M)
   2567996  58488068         - free -  (28G)
% fstyp /dev/da0
cd9660
% fstyp /dev/da0s2 
msdosfs
```

DSBMD will not let you mount the first FS (cd9660), because non-partitions/slices are skipped:
```
else if (is_parted(devname) && !match_part_dev(devname, 0)  {                        
            /* Only add slices of partitioned disks. */                                                                
            return (NULL); 
```

Why not simply check if the 'devname' is mountable and skip/add it to the devlist?
